### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ or clone to local, then
 
 Feel free to fork and send a pull request if you think you've improved anything.
 
-##New BSD License
+## New BSD License
 
 Copyright (c) 2012, Robin Zhong <fbzhong@gmail.com>
 All rights reserved.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
